### PR TITLE
Simple bugfixes/simplifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,12 @@ And see the details of each of the three parts.
 
   sudo mkdir -p /mnt/ram
 
-  echo "ramfs       /mnt/ram ramfs   nodev,nosuid,noexec,nodiratime,size=64M   0 0" | sudo tee -a /etc/fstab 
+  echo "ramfs       /mnt/ram ramfs   nodev,nosuid,noexec,nodiratime,size=64M,mode=1777   0 0" | sudo tee -a /etc/fstab 
+
+  sudo mount -a
 
 *** and finally to set your alarm for 733AM Mon-Fri
 
-  crontab -e 33 7 * * 1-5 sudo python /home/pi/sound_the_alarm.pi
+  crontab -e 33 7 * * 1-5 /home/pi/alarmpi/sound_the_alarm.py
 
 Thanks again to Michael Kidd for adding the config file and giving this project a real structure.  

--- a/sound_the_alarm.py
+++ b/sound_the_alarm.py
@@ -1,5 +1,9 @@
-#!/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import os
+import sys
+os.chdir(os.path.dirname(sys.argv[0])) # When called from cron, we can find our code
+
 import ConfigParser
 import subprocess
 import time
@@ -52,7 +56,7 @@ if Config.get('main','readaloud') == str(1):
     # Send shorts to Google and return mp3s
     try:
       for sentence in shorts:
-        sendthis = sentence.join(['"http://translate.google.com/translate_tts?tl=en&q=', '&client=t" -O /mnt/ram/'])
+        sendthis = sentence.join(['"http://translate.google.com/translate_tts?tl=en&q=', '&client=tw-ob" -O /mnt/ram/'])
         print(head + sendthis + str(count).zfill(2) + str(tail))
         print subprocess.call (head + sendthis + str(count).zfill(2) + str(tail), shell=True)
         count = count + 1


### PR DESCRIPTION
fixes #3 #5 
Updated README.md:

  -added ",mode=1777" to the fstab entry for /mnt/ram to make it
   behave like /tmp -- this will allow a non-root user to write
   to it.

  -added a "mount -a" line after the fstab modification to allow
   the ramdisk to be used immediately.

  -removed the unneeded "sudo python" portion in the crontab
   entry -- it is a good habit to get into to not run things
   as root. I also corrected a typo.

Updated sound_the_alarm.py:

  -force it to change directories to the script directory before
   doing anything else. This allows it to find its config file
   and the project modules.

  -modified the translate.google.com client per the comment by
   https://github.com/neondemon in issue #5.
      "change &clint=t to '&client=tw-ob"
